### PR TITLE
dyn expression node

### DIFF
--- a/dunge/tests/shader_dyn_false.wgsl
+++ b/dunge/tests/shader_dyn_false.wgsl
@@ -1,0 +1,14 @@
+struct VertexOutput {
+    @builtin(position) member: vec4<f32>,
+}
+
+@vertex 
+fn vs(@builtin(vertex_index) param: u32) -> VertexOutput {
+    let _e1: f32 = f32(param);
+    return VertexOutput(vec4<f32>(_e1, _e1, _e1, _e1));
+}
+
+@fragment 
+fn fs(param_1: VertexOutput) -> @location(0) vec4<f32> {
+    return vec4<f32>(1f, 1f, 1f, 1f);
+}

--- a/dunge/tests/shader_dyn_true.wgsl
+++ b/dunge/tests/shader_dyn_true.wgsl
@@ -1,0 +1,14 @@
+struct VertexOutput {
+    @builtin(position) member: vec4<f32>,
+}
+
+@vertex 
+fn vs(@builtin(vertex_index) param: u32) -> VertexOutput {
+    let _e2: f32 = sin(f32(param));
+    return VertexOutput(vec4<f32>(_e2, _e2, _e2, _e2));
+}
+
+@fragment 
+fn fs(param_1: VertexOutput) -> @location(0) vec4<f32> {
+    return vec4<f32>(1f, 1f, 1f, 1f);
+}

--- a/dunge_shader/src/dyn_expr.rs
+++ b/dunge_shader/src/dyn_expr.rs
@@ -1,0 +1,74 @@
+use std::marker::PhantomData;
+
+use crate::{
+    op::Ret,
+    sl::{Eval, Expr},
+};
+
+struct DynLander<T, O> {
+    a: Option<T>,
+    phantom: PhantomData<O>,
+}
+
+impl<E, T, O> Eval<E> for DynLander<T, O>
+where
+    T: Eval<E>,
+{
+    type Out = O;
+
+    fn eval(self, en: &mut E) -> crate::sl::Expr {
+        self.a.unwrap().eval(en)
+    }
+
+    fn eval_boxed(&mut self, en: &mut E) -> crate::sl::Expr
+    where
+        T: Eval<E>,
+    {
+        let mut new_self = DynLander {
+            a: None,
+            phantom: PhantomData,
+        };
+        std::mem::swap(&mut new_self, self);
+        new_self.eval(en)
+    }
+}
+pub struct DynRet<E, O> {
+    a: Box<dyn Eval<E, Out = O>>,
+}
+
+impl<E, O> DynRet<E, O> {
+    fn new<P>(a: Ret<P, O>) -> DynRet<E, O>
+    where
+        Ret<P, O>: Eval<E, Out = O>,
+        P: 'static,
+        O: 'static,
+    {
+        let lander: DynLander<Ret<P, O>, O> = DynLander {
+            a: Some(a),
+            phantom: PhantomData,
+        };
+        DynRet {
+            a: Box::new(lander),
+        }
+    }
+}
+
+/// Make a "dyn" or "type erased" expression from a concrete
+/// expression. This is useful if you want to change the shader
+/// definition based on runtime information.
+pub fn dyn_expr<P, E, O>(a: Ret<P, O>) -> Ret<DynRet<E, O>, O>
+where
+    Ret<P, O>: Eval<E, Out = O>,
+    P: 'static,
+    O: 'static,
+{
+    Ret::new(DynRet::new(a))
+}
+
+impl<E, O> Eval<E> for Ret<DynRet<E, O>, O> {
+    type Out = O;
+
+    fn eval(self, en: &mut E) -> Expr {
+        self.get().a.eval_boxed(en)
+    }
+}

--- a/dunge_shader/src/dyn_expr.rs
+++ b/dunge_shader/src/dyn_expr.rs
@@ -34,7 +34,7 @@ where
     where
         T: Eval<E>,
     {
-        let mut new_self = DynLander {
+        let mut new_self = Self {
             a: None,
             phantom: PhantomData,
         };
@@ -47,7 +47,7 @@ pub struct DynRet<E, O> {
 }
 
 impl<E, O> DynRet<E, O> {
-    fn new<P>(a: Ret<P, O>) -> DynRet<E, O>
+    fn new<P>(a: Ret<P, O>) -> Self
     where
         Ret<P, O>: Eval<E, Out = O>,
         P: 'static,
@@ -57,7 +57,7 @@ impl<E, O> DynRet<E, O> {
             a: Some(a),
             phantom: PhantomData,
         };
-        DynRet {
+        Self {
             a: Box::new(lander),
         }
     }

--- a/dunge_shader/src/eval.rs
+++ b/dunge_shader/src/eval.rs
@@ -116,13 +116,6 @@ impl FromIterator<Expr> for Exprs {
 pub trait Eval<E> {
     type Out;
     fn eval(self, en: &mut E) -> Expr;
-
-    /// Helper method required for "dyn" expressions whose
-    /// type depends on runtime information.  Do not implement
-    /// or call this method.  Should only be used within dyn_expr.
-    fn eval_boxed(&mut self, en: &mut E) -> Expr {
-        unreachable!("eval_boxed should only be used from dyn_expr()")
-    }
 }
 
 impl<E> Eval<E> for f32

--- a/dunge_shader/src/eval.rs
+++ b/dunge_shader/src/eval.rs
@@ -113,9 +113,16 @@ impl FromIterator<Expr> for Exprs {
     }
 }
 
-pub trait Eval<E>: Sized {
+pub trait Eval<E> {
     type Out;
     fn eval(self, en: &mut E) -> Expr;
+
+    /// Helper method required for "dyn" expressions whose
+    /// type depends on runtime information.  Do not implement
+    /// or call this method.  Should only be used within dyn_expr.
+    fn eval_boxed(&mut self, en: &mut E) -> Expr {
+        unreachable!("eval_boxed should only be used from dyn_expr()")
+    }
 }
 
 impl<E> Eval<E> for f32

--- a/dunge_shader/src/lib.rs
+++ b/dunge_shader/src/lib.rs
@@ -4,6 +4,7 @@ mod context;
 mod convert;
 mod define;
 mod discard;
+mod dyn_expr;
 mod eval;
 pub mod group;
 pub mod instance;
@@ -21,7 +22,7 @@ pub mod sl {
     //! Shader generator functions.
 
     pub use crate::{
-        branch::*, context::*, convert::*, define::*, discard::*, eval::*, math::*, matrix::*,
-        module::*, op::*, texture::*, vector::*, zero::*,
+        branch::*, context::*, convert::*, define::*, discard::*, dyn_expr::*, eval::*, math::*,
+        matrix::*, module::*, op::*, texture::*, vector::*, zero::*,
     };
 }


### PR DESCRIPTION
Make a way to construct "dyn" nodes, so that the concrete type of a shader can change depending on runtime information. I think this is the simplest/best way to make this work, but there might be a way to make this cleaner. 

Side note: Sorry for the flurry of PRs.  I think your approach in this crate is really cool & I'm thinking of adopting it.  Are you open to PRs and some more development, or should I just maintain my own fork?  Happy to chat in more detail about it.  Ultimately I need to assemble shaders that have runtime dynamic _inputs_, e.g. different storage buffers.