### PR TITLE
sketch out support for compute shaders

### DIFF
--- a/dunge/src/bind.rs
+++ b/dunge/src/bind.rs
@@ -29,7 +29,7 @@ pub trait VisitMember<'a> {
     fn visit_member(self, visitor: &mut Visitor<'a>);
 }
 
-impl<'a, V> VisitMember<'a> for &'a Storage<V> {
+impl<'a, V, S> VisitMember<'a> for &'a Storage<V, S> {
     fn visit_member(self, visitor: &mut Visitor<'a>) {
         let binding = self.buffer().as_entire_buffer_binding();
         visitor.push(BindingResource::Buffer(binding));

--- a/dunge/src/context.rs
+++ b/dunge/src/context.rs
@@ -14,6 +14,10 @@ use {
         value::{IntoValue, Value},
         Vertex,
     },
+    dunge_shader::{
+        sl::{IntoCsModule, Module},
+        types::StorageRead,
+    },
     std::{error, fmt, future::IntoFuture, sync::Arc},
 };
 
@@ -83,6 +87,15 @@ impl Context {
         Shader::new(&self.0, module)
     }
 
+    pub fn make_compute_shader<M, A>(&self, module: M) -> Module
+    where
+        M: IntoCsModule<A>,
+    {
+        let m = module.into_cs_module();
+        println!("{}", m.wgsl);
+        m
+    }
+
     pub fn make_binder<'a, V, I>(&'a self, shader: &'a Shader<V, I>) -> Binder<'a> {
         Binder::new(&self.0, shader)
     }
@@ -95,7 +108,7 @@ impl Context {
         Uniform::new(&self.0, val.value().as_ref())
     }
 
-    pub fn make_storage<U>(&self, data: &[U]) -> Storage<U>
+    pub fn make_read_storage<U>(&self, data: &[U]) -> Storage<U, StorageRead>
     where
         U: Value,
     {

--- a/dunge/src/group.rs
+++ b/dunge/src/group.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 
 pub use dunge_shader::group::Projection;
-use dunge_shader::types::{StorageAtomicReadWrite, StorageRead, StorageReadWrite};
+use dunge_shader::types::{StorageRead, StorageReadWrite};
 
 #[derive(Clone, Copy)]
 pub struct BoundTexture<'a>(pub(crate) &'a Texture2d);
@@ -69,20 +69,6 @@ where
 {
     const TYPE: MemberType = MemberType::writeable_array_from_value(V::TYPE);
     type Field = Ret<ReadGlobal, types::Array<V::Type, StorageReadWrite>>;
-
-    fn member_projection(id: u32, binding: u32, out: GlobalOut) -> Self::Field {
-        ReadGlobal::new(id, binding, Self::TYPE.is_value(), out)
-    }
-}
-
-impl<V> private::Sealed for &Storage<V, StorageAtomicReadWrite> where V: Value {}
-
-impl<V> MemberProjection for &Storage<V, StorageAtomicReadWrite>
-where
-    V: Value,
-{
-    const TYPE: MemberType = MemberType::atomic_array_from_value(V::TYPE);
-    type Field = Ret<ReadGlobal, types::Array<V::Type, StorageAtomicReadWrite>>;
 
     fn member_projection(id: u32, binding: u32, out: GlobalOut) -> Self::Field {
         ReadGlobal::new(id, binding, Self::TYPE.is_value(), out)

--- a/dunge/src/shader.rs
+++ b/dunge/src/shader.rs
@@ -149,6 +149,18 @@ impl Inner {
                         },
                         count: None,
                     },
+                    MemberType::WriteableArray(_) | MemberType::AtomicArray(_) => {
+                        BindGroupLayoutEntry {
+                            binding,
+                            visibility: visibility(info.stages),
+                            ty: BindingType::Buffer {
+                                ty: BufferBindingType::Storage { read_only: false },
+                                has_dynamic_offset: false,
+                                min_binding_size: None,
+                            },
+                            count: None,
+                        }
+                    }
                     MemberType::Tx2df => BindGroupLayoutEntry {
                         binding,
                         visibility: visibility(info.stages),
@@ -262,6 +274,9 @@ impl Inner {
                     vertex.push(vert);
                 }
                 InputInfo::Index => {}
+                InputInfo::GlobalInvocationId => {
+                    panic!("Invocation ID is an invalid argument for a vertex shader.")
+                }
             }
         }
 

--- a/dunge/src/shader.rs
+++ b/dunge/src/shader.rs
@@ -127,18 +127,19 @@ impl Inner {
             entries.clear();
             for (binding, member) in iter::zip(0.., info.def) {
                 let entry = match member {
-                    MemberType::Scalar(_) | MemberType::Vector(_) | MemberType::Matrix(_) => {
-                        BindGroupLayoutEntry {
-                            binding,
-                            visibility: visibility(info.stages),
-                            ty: BindingType::Buffer {
-                                ty: BufferBindingType::Uniform,
-                                has_dynamic_offset: false,
-                                min_binding_size: None,
-                            },
-                            count: None,
-                        }
-                    }
+                    MemberType::Scalar(_)
+                    | MemberType::Atomic(_)
+                    | MemberType::Vector(_)
+                    | MemberType::Matrix(_) => BindGroupLayoutEntry {
+                        binding,
+                        visibility: visibility(info.stages),
+                        ty: BindingType::Buffer {
+                            ty: BufferBindingType::Uniform,
+                            has_dynamic_offset: false,
+                            min_binding_size: None,
+                        },
+                        count: None,
+                    },
                     MemberType::Array(_) => BindGroupLayoutEntry {
                         binding,
                         visibility: visibility(info.stages),
@@ -314,6 +315,9 @@ where
             for _ in 0..mat.dims() {
                 to_format(ValueType::Vector(mat.vector_type()), f);
             }
+        }
+        ValueType::Atomic(s) => {
+            to_format(ValueType::Scalar(s), f);
         }
     }
 }

--- a/dunge/src/storage.rs
+++ b/dunge/src/storage.rs
@@ -4,6 +4,7 @@
 
 use {
     crate::{context::Context, state::State, value::Value},
+    dunge_shader::types::ArrayType,
     std::marker::PhantomData,
     wgpu::Buffer,
 };
@@ -11,13 +12,14 @@ use {
 /// Storage buffer data.
 ///
 /// Can be created using the context's [`make_storage`](crate::Context::make_storage) function.
-pub struct Storage<U> {
+pub struct Storage<U, S> {
     buf: Buffer,
     ty: PhantomData<U>,
+    st: PhantomData<S>,
     len: usize,
 }
 
-impl<U> Storage<U> {
+impl<U, S: ArrayType> Storage<U, S> {
     pub(crate) fn new(state: &State, contents: &[U]) -> Self
     where
         U: Value,
@@ -40,6 +42,7 @@ impl<U> Storage<U> {
         Self {
             buf,
             ty: PhantomData,
+            st: PhantomData,
             len: contents.len(),
         }
     }
@@ -68,7 +71,7 @@ impl<U> Storage<U> {
     }
 }
 
-impl<U> Storage<U> {
+impl<U, S> Storage<U, S> {
     pub(crate) fn buffer(&self) -> &Buffer {
         &self.buf
     }

--- a/dunge/src/value.rs
+++ b/dunge/src/value.rs
@@ -1,3 +1,5 @@
+use dunge_shader::types::Atomic;
+
 use crate::types::{self, MatrixType, ScalarType, ValueType, VectorType};
 
 /// Uniform value.
@@ -14,6 +16,18 @@ pub struct Data<const N: usize = 4>([f32; N]);
 impl<const N: usize> AsRef<[u8]> for Data<N> {
     fn as_ref(&self) -> &[u8] {
         bytemuck::cast_slice(&self.0)
+    }
+}
+
+impl private::Sealed for Atomic<u32> {}
+
+impl Value for Atomic<u32> {
+    const TYPE: ValueType = ValueType::Atomic(ScalarType::Uint);
+    type Type = Self;
+    type Data = Data;
+
+    fn value(self) -> Self::Data {
+        Data([self.0 as f32, 0., 0., 0.])
     }
 }
 

--- a/dunge/tests/atomic_compute_shader.wgsl
+++ b/dunge/tests/atomic_compute_shader.wgsl
@@ -1,0 +1,10 @@
+@group(0) @binding(0) 
+var<storage, read_write> global: array<f32>;
+@group(0) @binding(1) 
+var<storage, read_write> global_1: array<atomic<u32>>;
+
+@compute @workgroup_size(64, 1, 1) 
+fn cs(@builtin(global_invocation_id) param: vec3<u32>) {
+    let _e5: f32 = global[param.x];
+    let _e12: u32 = atomicAdd((&global_1[u32((_e5 / 100f))]), u32(1u));
+}

--- a/dunge/tests/compute_shader.rs
+++ b/dunge/tests/compute_shader.rs
@@ -1,0 +1,30 @@
+#![cfg(not(target_family = "wasm"))]
+
+use dunge::{
+    sl::{GlobalInvocationId, Groups},
+    storage::Storage,
+    types::StorageReadWrite,
+    Group,
+};
+
+type Error = Box<dyn std::error::Error>;
+
+#[test]
+fn simple_compute_shader() -> Result<(), Error> {
+    use dunge::sl::{self, CsOut};
+
+    #[derive(Group)]
+    struct Map<'a> {
+        array: &'a Storage<f32, StorageReadWrite>,
+    }
+
+    let compute = |GlobalInvocationId(inv): GlobalInvocationId, Groups(map): Groups<Map>| {
+        let set = map.array.set_index(inv.x(), sl::f32(1.0f32));
+        CsOut { compute: set }
+    };
+
+    let cx = helpers::block_on(dunge::context())?;
+    let module = cx.make_compute_shader(compute);
+    helpers::eq_lines(&module.wgsl, include_str!("simple_compute_shader.wgsl"));
+    Ok(())
+}

--- a/dunge/tests/shader.rs
+++ b/dunge/tests/shader.rs
@@ -1,5 +1,7 @@
 #![cfg(not(target_family = "wasm"))]
 
+use dunge::types::StorageRead;
+
 type Error = Box<dyn std::error::Error>;
 
 #[test]
@@ -181,7 +183,7 @@ fn shader_storage() -> Result<(), Error> {
 
     #[derive(Group)]
     struct Map<'a> {
-        array: &'a Storage<f32>,
+        array: &'a Storage<f32, StorageRead>,
     }
 
     let compute = |Groups(map): Groups<Map>, Index(index): Index| Out {

--- a/dunge/tests/simple_compute_shader.wgsl
+++ b/dunge/tests/simple_compute_shader.wgsl
@@ -1,0 +1,7 @@
+@group(0) @binding(0) 
+var<storage, read_write> global: array<f32>;
+
+@compute @workgroup_size(64, 1, 1) 
+fn cs(@builtin(global_invocation_id) param: vec3<u32>) {
+    global[param.x] = f32(1f);
+}

--- a/dunge_shader/Cargo.toml
+++ b/dunge_shader/Cargo.toml
@@ -12,6 +12,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
+bytemuck.workspace = true
 glam.workspace = true
 log.workspace = true
 naga = "24.0"

--- a/dunge_shader/src/atomic.rs
+++ b/dunge_shader/src/atomic.rs
@@ -1,0 +1,54 @@
+use crate::{
+    op::Ret,
+    sl::{Eval, GetEntry},
+    types::{Array, Atomic, StorageReadWrite},
+};
+
+pub struct AtomicOp<A, B, C> {
+    op: naga::AtomicFunction,
+    arr: A,
+    idx: B,
+    incr: C,
+}
+
+fn atomic_op<A, B, C>(
+    arr: A,
+    idx: B,
+    incr: C,
+    op: naga::AtomicFunction,
+) -> Ret<AtomicOp<A, B, C>, u32> {
+    let a = AtomicOp { op, arr, idx, incr };
+
+    Ret::new(a)
+}
+
+pub fn atomic_add<A, B, C, E>(arr: A, idx: B, incr: C) -> Ret<AtomicOp<A, B, C>, u32>
+where
+    A: Eval<E, Out = Array<Atomic<u32>, StorageReadWrite>>,
+    B: Eval<E, Out = u32>,
+    C: Eval<E, Out = u32>,
+{
+    atomic_op(arr, idx, incr, naga::AtomicFunction::Add)
+}
+
+impl<A, B, C, E> Eval<E> for Ret<AtomicOp<A, B, C>, u32>
+where
+    E: GetEntry,
+    A: Eval<E, Out = Array<Atomic<u32>, StorageReadWrite>>,
+    B: Eval<E, Out = u32>,
+    C: Eval<E, Out = u32>,
+{
+    type Out = u32;
+
+    fn eval(self, en: &mut E) -> crate::sl::Expr {
+        let me = self.get();
+        let arr = me.arr.eval(en);
+        let idx = me.idx.eval(en);
+        let access = en.get_entry().access(arr, idx);
+        let val = me.incr.eval(en);
+
+        let ty = <u32 as crate::types::Value>::VALUE_TYPE.ty();
+        let ty = en.get_entry().new_type(ty);
+        en.get_entry().atomic(access, val, me.op, ty)
+    }
+}

--- a/dunge_shader/src/cs_module.rs
+++ b/dunge_shader/src/cs_module.rs
@@ -1,0 +1,61 @@
+use crate::{
+    context::{Context, FromContext, FromContextInput},
+    eval::{self, Cs, Eval},
+    sl::Module,
+};
+
+pub trait IntoCsModule<A> {
+    type Instance;
+    fn into_cs_module(self) -> Module;
+}
+
+impl<M, P, O> IntoCsModule<()> for M
+where
+    M: FnOnce() -> CsOut<P, O>,
+    P: Eval<Cs, Out = O>,
+{
+    type Instance = ();
+
+    fn into_cs_module(self) -> Module {
+        let cx = Context::new();
+        eval::make_cs(cx, self)
+    }
+}
+
+macro_rules! impl_into_module {
+    (A $(,)? $($t:ident),*) => {
+        impl<M, P, O, A, $($t),*> IntoCsModule<(A, $($t),*)> for M
+        where
+            M: FnOnce(A, $($t),*) -> CsOut<P, O>,
+            A: FromContextInput,
+            P: Eval<Cs, Out = O>,
+            $(
+                $t: FromContext,
+            )*
+        {
+            type Instance = A::Instance;
+
+            #[allow(non_snake_case)]
+            fn into_cs_module(self) -> Module {
+                let mut cx = Context::new();
+                let a = A::from_context_input(&mut cx);
+                $(
+                    let $t = $t::from_context(&mut cx);
+                )*
+                eval::make_cs(cx, || self(a, $($t),*))
+            }
+        }
+    };
+}
+
+impl_into_module!(A);
+impl_into_module!(A, B);
+impl_into_module!(A, B, C);
+impl_into_module!(A, B, C, D);
+
+pub struct CsOut<P, O>
+where
+    P: Eval<Cs, Out = O>,
+{
+    pub compute: P,
+}

--- a/dunge_shader/src/eval.rs
+++ b/dunge_shader/src/eval.rs
@@ -52,7 +52,9 @@ where
             ty: compl.define_index(),
             binding: Some(Binding::BuiltIn(BuiltIn::VertexIndex)),
         },
-        _ => unreachable!(),
+        InputInfo::GlobalInvocationId => {
+            unreachable!("can't use GlobalInvocationId in compute shader")
+        }
     };
 
     let inputs: Vec<_> = cx.inputs.iter().map(make_input).collect();

--- a/dunge_shader/src/lib.rs
+++ b/dunge_shader/src/lib.rs
@@ -1,4 +1,5 @@
 mod access;
+mod atomic;
 mod branch;
 mod context;
 mod convert;
@@ -22,7 +23,7 @@ pub mod sl {
     //! Shader generator functions.
 
     pub use crate::{
-        branch::*, context::*, convert::*, cs_module::*, define::*, discard::*, eval::*, math::*,
-        matrix::*, module::*, op::*, texture::*, vector::*, zero::*,
+        atomic::*, branch::*, context::*, convert::*, cs_module::*, define::*, discard::*, eval::*,
+        math::*, matrix::*, module::*, op::*, texture::*, vector::*, zero::*,
     };
 }

--- a/dunge_shader/src/lib.rs
+++ b/dunge_shader/src/lib.rs
@@ -2,6 +2,7 @@ mod access;
 mod branch;
 mod context;
 mod convert;
+mod cs_module;
 mod define;
 mod discard;
 mod eval;
@@ -21,7 +22,7 @@ pub mod sl {
     //! Shader generator functions.
 
     pub use crate::{
-        branch::*, context::*, convert::*, define::*, discard::*, eval::*, math::*, matrix::*,
-        module::*, op::*, texture::*, vector::*, zero::*,
+        branch::*, context::*, convert::*, cs_module::*, define::*, discard::*, eval::*, math::*,
+        matrix::*, module::*, op::*, texture::*, vector::*, zero::*,
     };
 }

--- a/dunge_shader/src/types.rs
+++ b/dunge_shader/src/types.rs
@@ -13,6 +13,7 @@ pub enum ValueType {
     Scalar(ScalarType),
     Vector(VectorType),
     Matrix(MatrixType),
+    Atomic(ScalarType),
 }
 
 impl ValueType {
@@ -21,6 +22,14 @@ impl ValueType {
             Self::Scalar(v) => v.ty(),
             Self::Vector(v) => v.ty(),
             Self::Matrix(v) => v.ty(),
+            Self::Atomic(v) => {
+                let (kind, width) = v.inner();
+                let scalar = naga::Scalar { kind, width };
+                Type {
+                    name: None,
+                    inner: TypeInner::Atomic(scalar),
+                }
+            }
         }
     }
 
@@ -83,6 +92,14 @@ pub trait Number: Scalar {}
 impl Number for f32 {}
 impl Number for i32 {}
 impl Number for u32 {}
+
+#[derive(Clone, Copy)]
+pub struct Atomic<T>(pub T);
+unsafe impl bytemuck::NoUninit for Atomic<u32> {}
+
+impl Value for Atomic<u32> {
+    const VALUE_TYPE: ValueType = ValueType::Atomic(ScalarType::Uint);
+}
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum ScalarType {
@@ -374,19 +391,13 @@ impl ArrayType for StorageReadWrite {
     const STORAGE_ACCESS: StorageAccess = StorageAccess::LOAD.union(StorageAccess::STORE);
 }
 
-pub struct StorageAtomicReadWrite {}
-impl ArrayType for StorageAtomicReadWrite {
-    const STORAGE_ACCESS: StorageAccess = StorageAccess::LOAD
-        .union(StorageAccess::STORE)
-        .union(StorageAccess::ATOMIC);
-}
-
 /// A storage or uniform array.
 pub struct Array<T, S>(PhantomData<T>, PhantomData<S>);
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum MemberType {
     Scalar(ScalarType),
+    Atomic(ScalarType),
     Array(ValueType),
     WriteableArray(ValueType),
     AtomicArray(ValueType),
@@ -402,31 +413,20 @@ impl MemberType {
             ValueType::Scalar(v) => Self::Scalar(v),
             ValueType::Vector(v) => Self::Vector(v),
             ValueType::Matrix(v) => Self::Matrix(v),
+            ValueType::Atomic(v) => Self::Scalar(v),
         }
     }
 
     pub const fn array_from_value(v: ValueType) -> Self {
-        match v {
-            ValueType::Scalar(v) => Self::Array(ValueType::Scalar(v)),
-            ValueType::Vector(v) => Self::Array(ValueType::Vector(v)),
-            ValueType::Matrix(v) => Self::Array(ValueType::Matrix(v)),
-        }
+        Self::Array(v)
     }
 
     pub const fn writeable_array_from_value(v: ValueType) -> Self {
-        match v {
-            ValueType::Scalar(v) => Self::WriteableArray(ValueType::Scalar(v)),
-            ValueType::Vector(v) => Self::WriteableArray(ValueType::Vector(v)),
-            ValueType::Matrix(v) => Self::WriteableArray(ValueType::Matrix(v)),
-        }
+        Self::WriteableArray(v)
     }
 
     pub const fn atomic_array_from_value(v: ValueType) -> Self {
-        match v {
-            ValueType::Scalar(v) => Self::AtomicArray(ValueType::Scalar(v)),
-            ValueType::Vector(v) => Self::AtomicArray(ValueType::Vector(v)),
-            ValueType::Matrix(v) => Self::AtomicArray(ValueType::Matrix(v)),
-        }
+        Self::AtomicArray(v)
     }
 
     pub const fn is_value(self) -> bool {
@@ -466,6 +466,15 @@ impl MemberType {
                 types.insert(t.clone(), span)
             }
             Self::Scalar(v) => q(v.ty()),
+            Self::Atomic(v) => {
+                let (kind, width) = v.inner();
+                let s = naga::Scalar { kind, width };
+                let atomic = Type {
+                    name: None,
+                    inner: TypeInner::Atomic(s),
+                };
+                types.insert(atomic, span)
+            }
             Self::Vector(v) => q(v.ty()),
             Self::Matrix(v) => q(v.ty()),
             Self::Tx2df => q(TEXTURE2DF),
@@ -475,7 +484,9 @@ impl MemberType {
 
     pub(crate) const fn address_space(self) -> AddressSpace {
         match self {
-            Self::Scalar(_) | Self::Vector(_) | Self::Matrix(_) => AddressSpace::Uniform,
+            Self::Scalar(_) | Self::Vector(_) | Self::Matrix(_) | Self::Atomic(_) => {
+                AddressSpace::Uniform
+            }
             Self::Array(_) => AddressSpace::Storage {
                 access: StorageAccess::LOAD,
             },

--- a/dunge_shader/src/types.rs
+++ b/dunge_shader/src/types.rs
@@ -441,14 +441,18 @@ impl MemberType {
             Self::Array(v) | Self::WriteableArray(v) | Self::AtomicArray(v) => {
                 let base = types.insert(v.ty(), span);
                 let size = match v.ty().inner {
-                    TypeInner::Scalar(scalar) | TypeInner::Atomic(scalar) => scalar.width as u32,
-                    TypeInner::Vector { size, scalar } => size as u32 * scalar.width as u32,
+                    TypeInner::Scalar(scalar) | TypeInner::Atomic(scalar) => {
+                        u32::from(scalar.width)
+                    }
+                    TypeInner::Vector { size, scalar } => size as u32 * u32::from(scalar.width),
                     // matrices are treated as arrays of aligned columns
                     TypeInner::Matrix {
                         columns,
                         rows,
                         scalar,
-                    } => naga::proc::Alignment::from(rows) * scalar.width as u32 * columns as u32,
+                    } => {
+                        naga::proc::Alignment::from(rows) * u32::from(scalar.width) * columns as u32
+                    }
                     _ => panic!("unknown size"),
                 };
                 let t = Type {
@@ -456,7 +460,7 @@ impl MemberType {
                     inner: TypeInner::Array {
                         base,
                         size: naga::ArraySize::Dynamic,
-                        stride: u32::from(size),
+                        stride: size,
                     },
                 };
                 types.insert(t.clone(), span)


### PR DESCRIPTION
for discussion purposes, to see if this is on the right track.  Compute shaders can only communicate results by writing into writeable storage buffers, so this also adds support for writeable storage buffers, and setting values on them.

Some additional things will be required to flesh out support (maybe in later PRs):
- [ ] machinery to actually launch compute shaders
- [ ] read back of results buffers to CPU
- [ ] atomic functions for e.g. histogramming
